### PR TITLE
Add a simple layout for text pages.

### DIFF
--- a/_layouts/just-text.html
+++ b/_layouts/just-text.html
@@ -1,0 +1,6 @@
+---
+layout: default
+---
+<article>
+  {{ content }}
+</article>

--- a/css/main.scss
+++ b/css/main.scss
@@ -36,11 +36,11 @@ header, footer {
   a {
     text-decoration: none;
   }
+}
 
-  nav {
-    max-width: 1024px;
-    margin: 0 auto;
-  }
+nav, article {
+  max-width: 1024px;
+  margin: 0 auto;
 }
 
 footer {


### PR DESCRIPTION
Now, use the `layout: just-text` to get a simple page with just text content.