### PR TITLE
Use relative URL filter everywhere

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 ---
 language: ruby
-script: bundle exec jekyll build --strict_front_matter
+script: bundle exec jekyll build --strict_front_matter --config _config.yml,_production.yml

--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@ description: > # this means to ignore newlines until "baseurl:"
   Write an awesome description for your new site here. You can edit this
   line in _config.yml. It will appear in your document head meta (for
   Google search results) and in your feed.xml site description.
-baseurl: "" # the subpath of your site, e.g. /blog
+baseurl: "/ellianderpictures.co.uk/" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: jekyllrb
 github_username:  jekyll

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,7 +3,7 @@
   <nav>
     {% for name in site.menu %}
     {% assign node = site.pages | where: 'name', name | first %}
-    <a href="{{ node.url }}"{% if page.url == node.url %} class="selected"{% endif %}> {{ node.title }} </a>
+    <a href="{{ node.url | relative_url }}"{% if page.url == node.url %} class="selected"{% endif %}> {{ node.title }} </a>
     {% endfor %}
   </nav>
 </header>

--- a/_layouts/slides.html
+++ b/_layouts/slides.html
@@ -30,8 +30,13 @@ scrollFraction = function() {
       sh = 'scrollHeight';
     return (h[st]||b[st]) / ((h[sh]||b[sh]) - h.clientHeight);
 }
+getStyle = function(el) {
+  return (typeof getComputedStyle !== 'undefined' ? getComputedStyle(el, null) : el.currentStyle);
+}
 window.addEventListener('scroll', function(e) {
-  newLeft = scrollFraction() * -920 * ({{ films.size }} - 1);
+  var style = getStyle(document.querySelector('.slide'));
+  var slideWidth = (parseFloat(style.width) + parseFloat(style.marginRight) + parseFloat(style.marginLeft));
+  var newLeft = scrollFraction() * -slideWidth * ({{ films.size }} - 1);
   changePosition(newLeft);
 });
 changePosition(0);

--- a/_layouts/slides.html
+++ b/_layouts/slides.html
@@ -7,8 +7,8 @@ layout: default
   {% assign films = list[0]['docs'] | sort: 'year' | reverse %}
   {% for film in films %}
   <div class="slide">
-    <video src="{{ film.url }}/../{{ film.video_url }}" autoplay muted loop></video>
-    <a href="{{ film.url }}">
+    <video src="{{ film.url | relative_url }}/../{{ film.video_url }}" autoplay muted loop></video>
+    <a href="{{ film.url | relative_url }}">
       <h1>{{ film.name }}</h1>
       <h2>{{ film.kind }}, {{ film.year }}</h2>
     </a>

--- a/_layouts/slides.html
+++ b/_layouts/slides.html
@@ -23,8 +23,15 @@ document.querySelector('.slides').style['width'] = 'calc(' + ({{ films.size }}) 
 changePosition = function(newLeft) {
   document.querySelector('.slides').style['left'] = 'calc(' + newLeft + 'px + 50%)';
 }
+scrollFraction = function() {
+  var h = document.documentElement,
+      b = document.body,
+      st = 'scrollTop',
+      sh = 'scrollHeight';
+    return (h[st]||b[st]) / ((h[sh]||b[sh]) - h.clientHeight);
+}
 window.addEventListener('scroll', function(e) {
-  newLeft = (e.pageY / e.view.scrollMaxY) * -920 * ({{ films.size }} - 1);
+  newLeft = scrollFraction() * -920 * ({{ films.size }} - 1);
   changePosition(newLeft);
 });
 changePosition(0);

--- a/_production.yml
+++ b/_production.yml
@@ -1,0 +1,5 @@
+---
+# Here we set the baseurl back to the root.
+# This config file won't be loaded by Github
+# but will be used to build the production version of the site.
+baseurl: '/'


### PR DESCRIPTION
- This allows slides and links to work on
  GitHub preview properly.
- Set baseurl differently when we build for
  the real site.
- Can test locally using --config switch.
- Fixes #10.